### PR TITLE
Additional formatting for production haproxy.cfg

### DIFF
--- a/Haproxy.tmLanguage
+++ b/Haproxy.tmLanguage
@@ -160,7 +160,7 @@
       <!-- Everything else -->
       <dict>
         <key>match</key>
-        <string>\/[\w\.]+</string>
+        <string>\/[\w\.\-\?=]+</string>
         <key>name</key>
         <string>string.other</string>
       </dict>

--- a/Haproxy.tmLanguage
+++ b/Haproxy.tmLanguage
@@ -55,7 +55,7 @@
       <!-- Keywords -->
       <dict>
         <key>match</key>
-        <string>\b(acl|appsession|backlog|balance|bind|bind-process|block|ca-base|chroot|compression|cookie|crt-base|daemon|default-server|default_backend|description|disabled|dispatch|enabled|errorfile|errorloc|errorloc302|errorloc303|force-persist|fullconn|grace|hash-type|id|ignore-persist|lua-load|log-format|log|mode|monitor\s+fail|monitor-net|monitor-uri|persist\s+rdp-cookie|rate-limit\s+sessions|redirect|reqadd|reqallow|reqdel|reqdeny|reqiallow|reqidel|reqideny|reqipass|reqirep|reqisetbe|reqitarpit|reqpass|reqrep|reqsetbe|reqtarpit|retries|rspadd|rspdel|rspdeny|rspidel|rspideny|rspirep|rsprep|server|source|ssl-default-bind-(ciphers|options)|unique-id-(format|header)|use(_backend|-server))\b</string>
+        <string>\b(acl|appsession|backlog|balance|bind|bind-process|block|ca-base|chroot|compression|cookie|crt-base|daemon|nbproc|cpu-map|default-server|default_backend|description|disabled|dispatch|enabled|errorfile|errorloc|errorloc302|errorloc303|force-persist|fullconn|grace|hash-type|id|ignore-persist|lua-load|log-format|log|mode|monitor\s+fail|monitor-net|monitor-uri|persist\s+rdp-cookie|rate-limit\s+sessions|redirect|reqadd|reqallow|reqdel|reqdeny|reqiallow|reqidel|reqideny|reqipass|reqirep|reqisetbe|reqitarpit|reqpass|reqrep|reqsetbe|reqtarpit|retries|rspadd|rspdel|rspdeny|rspidel|rspideny|rspirep|rsprep|server|source|ssl-default-bind-(ciphers|options)|unique-id-(format|header)|use(_backend|-server))\b</string>
         <key>name</key>
         <string>keyword</string>
       </dict>

--- a/Haproxy.tmLanguage
+++ b/Haproxy.tmLanguage
@@ -31,6 +31,13 @@
         <key>name</key>
         <string>constant.numeric</string>
       </dict>
+      <!-- Ciphers -->
+      <dict>
+        <key>match</key>
+        <string>\bciphers\s+[^\b]+\b</string>
+        <key>name</key>
+        <string>string.other</string>
+      </dict>
       <!-- Numeric Constants -->
       <dict>
         <key>match</key>

--- a/Haproxy.tmLanguage
+++ b/Haproxy.tmLanguage
@@ -96,7 +96,7 @@
       <!-- Stats keyword combinations -->
       <dict>
         <key>match</key>
-        <string>\b(stats\s+(admin|auth|enable|hide-version|http-request|realm|refresh|scope|show-desc|show-legends|show-node|socket|timeout|uri))\b</string>
+        <string>\b(stats\s+(admin|auth|enable|bind-process|hide-version|http-request|realm|refresh|scope|show-desc|show-legends|show-node|socket|timeout|uri))\b</string>
         <key>name</key>
         <string>keyword</string>
       </dict>

--- a/Haproxy.tmLanguage
+++ b/Haproxy.tmLanguage
@@ -69,6 +69,12 @@
       <!-- Http Keyword Combinations -->
       <dict>
         <key>match</key>
+        <string>\b(status|rstatus|rstring|string)\s+.+</string>
+        <key>name</key>
+        <string>string.quoted.double</string>
+      </dict>
+      <dict>
+        <key>match</key>
         <string>\b(http-check\s+(disable-on-404|expect|send-state)|http-(request|response))\b</string>
         <key>name</key>
         <string>keyword</string>
@@ -162,7 +168,7 @@
         <key>match</key>
         <string>\/[\w\.\-\?=]+</string>
         <key>name</key>
-        <string>string.other</string>
+        <string>variable.parameter</string>
       </dict>
     </array>
     <key>scopeName</key>


### PR DESCRIPTION
Cleans up some string matching pattern and provides additional patterns. Tested against **haproxy.cfg** used in production.