### PR TITLE
Fix: allow more characters in path parameters.

### DIFF
--- a/Haproxy.tmLanguage
+++ b/Haproxy.tmLanguage
@@ -187,7 +187,7 @@
       <!-- Everything else -->
       <dict>
         <key>match</key>
-        <string>\/[\w\.\-\?=]+</string>
+        <string>/[-+\w/\\|^.:;@%!$*?=~(){}\[\]`"'#&lt;&gt;&amp;]*</string>
         <key>name</key>
         <string>variable.parameter</string>
       </dict>


### PR DESCRIPTION
Also changed quantifier + to *.
Check https://tools.ietf.org/html/rfc3987#page-7 for all valid URI path characters.